### PR TITLE
Replace equivalent fmt.Sprintf calls with strconv.Itoa

### DIFF
--- a/logger/logger_test.go
+++ b/logger/logger_test.go
@@ -1,8 +1,10 @@
 package logger
 
-import "testing"
+import (
+	"testing"
 
-import "github.com/sirupsen/logrus"
+	"github.com/sirupsen/logrus"
+)
 
 func TestLogLevel(t *testing.T) {
 	tests := map[string]logrus.Level{

--- a/models/campaign_test.go
+++ b/models/campaign_test.go
@@ -2,6 +2,7 @@ package models
 
 import (
 	"fmt"
+	"strconv"
 	"testing"
 	"time"
 
@@ -156,7 +157,7 @@ func setupCampaignDependencies(b *testing.B, size int) {
 	group := Group{Name: "Test Group"}
 	// Create a large group of 5000 members
 	for i := 0; i < size; i++ {
-		group.Targets = append(group.Targets, Target{BaseRecipient: BaseRecipient{Email: fmt.Sprintf("test%d@example.com", i), FirstName: "User", LastName: fmt.Sprintf("%d", i)}})
+		group.Targets = append(group.Targets, Target{BaseRecipient: BaseRecipient{Email: fmt.Sprintf("test%d@example.com", i), FirstName: "User", LastName: strconv.Itoa(i)}})
 	}
 	group.UserId = 1
 	err := PostGroup(&group)

--- a/models/group_test.go
+++ b/models/group_test.go
@@ -2,6 +2,7 @@ package models
 
 import (
 	"fmt"
+	"strconv"
 	"testing"
 
 	"github.com/jinzhu/gorm"
@@ -183,7 +184,7 @@ func benchmarkPostGroup(b *testing.B, iter, size int) {
 		g.Targets = append(g.Targets, Target{
 			BaseRecipient: BaseRecipient{
 				FirstName: "User",
-				LastName:  fmt.Sprintf("%d", i),
+				LastName:  strconv.Itoa(i),
 				Email:     fmt.Sprintf("test-%d@test.com", i),
 			},
 		})
@@ -206,7 +207,7 @@ func benchmarkPutGroup(b *testing.B, iter, size int) {
 		g.Targets = append(g.Targets, Target{
 			BaseRecipient: BaseRecipient{
 				FirstName: "User",
-				LastName:  fmt.Sprintf("%d", i),
+				LastName:  strconv.Itoa(i),
 				Email:     fmt.Sprintf("test-%d@test.com", i),
 			},
 		})


### PR DESCRIPTION
This batch change replaces `fmt.Sprintf("%d", integer)` calls with semantically equivalent `strconv.Itoa` calls

[_Created by Sourcegraph batch change `malo/fmt-sprintf-strcomvitoa`._](https://demo.sourcegraph.com/users/malo/batch-changes/fmt-sprintf-strcomvitoa)