### PR TITLE
Go 1.18: rewrite `interface{}` to `any`

### DIFF
--- a/context/context-legacy.go
+++ b/context/context-legacy.go
@@ -1,3 +1,4 @@
+//go:build !go1.7
 // +build !go1.7
 
 package context
@@ -8,11 +9,11 @@ import (
 	"github.com/gorilla/context"
 )
 
-func Get(r *http.Request, key interface{}) interface{} {
+func Get(r *http.Request, key any) any {
 	return context.Get(r, key)
 }
 
-func Set(r *http.Request, key, val interface{}) *http.Request {
+func Set(r *http.Request, key, val any) *http.Request {
 	if val == nil {
 		return r
 	}

--- a/context/context.go
+++ b/context/context.go
@@ -1,3 +1,4 @@
+//go:build go1.7
 // +build go1.7
 
 package context
@@ -9,12 +10,12 @@ import (
 )
 
 // Get retrieves a value from the request context
-func Get(r *http.Request, key interface{}) interface{} {
+func Get(r *http.Request, key any) any {
 	return r.Context().Value(key)
 }
 
 // Set stores a value on the request context
-func Set(r *http.Request, key, val interface{}) *http.Request {
+func Set(r *http.Request, key, val any) *http.Request {
 	if val == nil {
 		return r
 	}

--- a/controllers/api/response.go
+++ b/controllers/api/response.go
@@ -10,7 +10,7 @@ import (
 
 // JSONResponse attempts to set the status code, c, and marshal the given interface, d, into a response that
 // is written to the given ResponseWriter.
-func JSONResponse(w http.ResponseWriter, d interface{}, c int) {
+func JSONResponse(w http.ResponseWriter, d any, c int) {
 	dj, err := json.MarshalIndent(d, "", "  ")
 	if err != nil {
 		http.Error(w, "Error creating JSON response", http.StatusInternalServerError)

--- a/controllers/route.go
+++ b/controllers/route.go
@@ -173,7 +173,7 @@ func (as *AdminServer) registerRoutes() {
 
 type templateParams struct {
 	Title        string
-	Flashes      []interface{}
+	Flashes      []any
 	User         models.User
 	Token        string
 	Version      string
@@ -311,7 +311,7 @@ func (as *AdminServer) handleInvalidLogin(w http.ResponseWriter, r *http.Request
 	params := struct {
 		User    models.User
 		Title   string
-		Flashes []interface{}
+		Flashes []any
 		Token   string
 	}{Title: "Login", Token: csrf.Token(r)}
 	params.Flashes = session.Flashes()
@@ -357,7 +357,7 @@ func (as *AdminServer) Login(w http.ResponseWriter, r *http.Request) {
 	params := struct {
 		User    models.User
 		Title   string
-		Flashes []interface{}
+		Flashes []any
 		Token   string
 	}{Title: "Login", Token: csrf.Token(r)}
 	session := ctx.Get(r, "session").(*sessions.Session)

--- a/imap/imap.go
+++ b/imap/imap.go
@@ -23,7 +23,7 @@ type Client interface {
 	Login(username, password string) (cmd *imap.Command, err error)
 	Logout(timeout time.Duration) (cmd *imap.Command, err error)
 	Select(name string, readOnly bool) (mbox *imap.MailboxStatus, err error)
-	Store(seq *imap.SeqSet, item imap.StoreItem, value interface{}, ch chan *imap.Message) (err error)
+	Store(seq *imap.SeqSet, item imap.StoreItem, value any, ch chan *imap.Message) (err error)
 	Fetch(seqset *imap.SeqSet, items []imap.FetchItem, ch chan *imap.Message) (err error)
 }
 

--- a/logger/logger.go
+++ b/logger/logger.go
@@ -52,52 +52,52 @@ func Setup(config *Config) error {
 }
 
 // Debug logs a debug message
-func Debug(args ...interface{}) {
+func Debug(args ...any) {
 	Logger.Debug(args...)
 }
 
 // Debugf logs a formatted debug messsage
-func Debugf(format string, args ...interface{}) {
+func Debugf(format string, args ...any) {
 	Logger.Debugf(format, args...)
 }
 
 // Info logs an informational message
-func Info(args ...interface{}) {
+func Info(args ...any) {
 	Logger.Info(args...)
 }
 
 // Infof logs a formatted informational message
-func Infof(format string, args ...interface{}) {
+func Infof(format string, args ...any) {
 	Logger.Infof(format, args...)
 }
 
 // Error logs an error message
-func Error(args ...interface{}) {
+func Error(args ...any) {
 	Logger.Error(args...)
 }
 
 // Errorf logs a formatted error message
-func Errorf(format string, args ...interface{}) {
+func Errorf(format string, args ...any) {
 	Logger.Errorf(format, args...)
 }
 
 // Warn logs a warning message
-func Warn(args ...interface{}) {
+func Warn(args ...any) {
 	Logger.Warn(args...)
 }
 
 // Warnf logs a formatted warning message
-func Warnf(format string, args ...interface{}) {
+func Warnf(format string, args ...any) {
 	Logger.Warnf(format, args...)
 }
 
 // Fatal logs a fatal error message
-func Fatal(args ...interface{}) {
+func Fatal(args ...any) {
 	Logger.Fatal(args...)
 }
 
 // Fatalf logs a formatted fatal error message
-func Fatalf(format string, args ...interface{}) {
+func Fatalf(format string, args ...any) {
 	Logger.Fatalf(format, args...)
 }
 

--- a/models/group.go
+++ b/models/group.go
@@ -342,7 +342,7 @@ func insertTargetIntoGroup(tx *gorm.DB, t Target, gid int64) error {
 
 // UpdateTarget updates the given target information in the database.
 func UpdateTarget(tx *gorm.DB, target Target) error {
-	targetInfo := map[string]interface{}{
+	targetInfo := map[string]any{
 		"first_name": target.FirstName,
 		"last_name":  target.LastName,
 		"position":   target.Position,

--- a/models/models.go
+++ b/models/models.go
@@ -69,9 +69,9 @@ type Flash struct {
 
 // Response contains the attributes found in an API response
 type Response struct {
-	Message string      `json:"message"`
-	Success bool        `json:"success"`
-	Data    interface{} `json:"data"`
+	Message string `json:"message"`
+	Success bool   `json:"success"`
+	Data    any    `json:"data"`
 }
 
 // Copy of auth.GenerateSecureKey to prevent cyclic import with auth library

--- a/models/result.go
+++ b/models/result.go
@@ -38,7 +38,7 @@ type Result struct {
 	BaseRecipient
 }
 
-func (r *Result) createEvent(status string, details interface{}) (*Event, error) {
+func (r *Result) createEvent(status string, details any) (*Event, error) {
 	e := &Event{Email: r.Email, Message: status}
 	if details != nil {
 		dj, err := json.Marshal(details)

--- a/models/template_context.go
+++ b/models/template_context.go
@@ -74,7 +74,7 @@ func NewPhishingTemplateContext(ctx TemplateContext, r BaseRecipient, rid string
 
 // ExecuteTemplate creates a templated string based on the provided
 // template body and data.
-func ExecuteTemplate(text string, data interface{}) (string, error) {
+func ExecuteTemplate(text string, data any) (string, error) {
 	buff := bytes.Buffer{}
 	tmpl, err := template.New("template").Parse(text)
 	if err != nil {

--- a/webhook/webhook.go
+++ b/webhook/webhook.go
@@ -35,7 +35,7 @@ const (
 
 // Sender represents a type which can send webhooks to an EndPoint
 type Sender interface {
-	Send(endPoint EndPoint, data interface{}) error
+	Send(endPoint EndPoint, data any) error
 }
 
 type defaultSender struct {
@@ -64,12 +64,12 @@ type EndPoint struct {
 }
 
 // Send sends data to a single EndPoint
-func Send(endPoint EndPoint, data interface{}) error {
+func Send(endPoint EndPoint, data any) error {
 	return senderInstance.Send(endPoint, data)
 }
 
 // SendAll sends data to multiple EndPoints
-func SendAll(endPoints []EndPoint, data interface{}) {
+func SendAll(endPoints []EndPoint, data any) {
 	for _, e := range endPoints {
 		go func(e EndPoint) {
 			senderInstance.Send(e, data)
@@ -78,7 +78,7 @@ func SendAll(endPoints []EndPoint, data interface{}) {
 }
 
 // Send contains the implementation of sending webhook to an EndPoint
-func (ds defaultSender) Send(endPoint EndPoint, data interface{}) error {
+func (ds defaultSender) Send(endPoint EndPoint, data any) error {
 	jsonData, err := json.Marshal(data)
 	if err != nil {
 		log.Error(err)

--- a/webhook/webhook_test.go
+++ b/webhook/webhook_test.go
@@ -22,7 +22,7 @@ func newMockSender() *mockSender {
 	return ms
 }
 
-func (ms mockSender) Send(endPoint EndPoint, data interface{}) error {
+func (ms mockSender) Send(endPoint EndPoint, data any) error {
 	log.Println("[test] mocked 'Send' function")
 	return nil
 }
@@ -44,7 +44,7 @@ func TestSendMocked(t *testing.T) {
 func TestSendReal(t *testing.T) {
 	expectedSig := "004b36ca3fcbc01a08b17bf5d4a7e1aa0b10e14f55f3f8bd9acac0c7e8d2635d"
 	secret := "secret456"
-	data := map[string]interface{}{
+	data := map[string]any{
 		"key1": "val1",
 		"key2": "val2",
 		"key3": "val3",
@@ -71,7 +71,7 @@ func TestSendReal(t *testing.T) {
 			t.Fatalf("error reading JSON body from webhook request: %v", err)
 		}
 
-		var payload map[string]interface{}
+		var payload map[string]any
 		err = json.Unmarshal(body, &payload)
 		if err != nil {
 			t.Fatalf("error unmarshaling webhook payload: %v", err)


### PR DESCRIPTION
Rewrites `interface{}` to `any` using `gofmt`

[_Created by Sourcegraph batch change `christine/Go-upgrade-type`._](https://demo.sourcegraph.com/users/christine/batch-changes/Go-upgrade-type)